### PR TITLE
Some revamp to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Available in: <img src="https://upload.wikimedia.org/wikipedia/commons/a/ae/Flag
 ### System Requirements
 
 | Version                         | Marketing name      | Build       | Arch | Editions                 |
-|:------------------------------- | -------------------:|:-----------:|:----:|:------------------------:|
+|:-------------------------------:|:-------------------:|:-----------:|:----:|:------------------------:|
 | Windows 11 Insider Preview 23H2 | 2023 Update         | 25206+      |      | Home/Pro/Enterprise      |
 | Windows 11 22H2                 | 2022 Update         | 22621+      |      | Home/Pro/Enterprise      |
 | Windows 11 21H2                 |                     | 22000.739+  |      | Home/Pro/Enterprise      |

--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@
 
   [discord-news-badge]: https://discordapp.com/api/guilds/1006179075263561779/widget.png?style=shield
   [discord-link]: https://discord.gg/sSryhaEv79
+
   [![Discord][discord-news-badge]][discord-link]
+
 </p>
 
 Available in: <img src="https://upload.wikimedia.org/wikipedia/commons/a/ae/Flag_of_the_United_Kingdom.svg" height="11px"/> <img src="https://upload.wikimedia.org/wikipedia/commons/f/f3/Flag_of_Russia.svg" height="11px"/> <img src="https://upload.wikimedia.org/wikipedia/commons/4/49/Flag_of_Ukraine.svg" height="11px"/> <img src="https://upload.wikimedia.org/wikipedia/commons/b/ba/Flag_of_Germany.svg" height="11px"/> <img src="https://upload.wikimedia.org/wikipedia/commons/0/03/Flag_of_Italy.svg" height="11px"/> <img src="https://upload.wikimedia.org/wikipedia/commons/b/b4/Flag_of_Turkey.svg" height="11px"/> <img src="https://upload.wikimedia.org/wikipedia/commons/c/c3/Flag_of_France.svg" height="11px"/> <img src="https://upload.wikimedia.org/wikipedia/commons/c/cb/Flag_of_the_Czech_Republic.svg" height="11px"/> <img src="https://upload.wikimedia.org/wikipedia/commons/f/fa/Flag_of_the_People's_Republic_of_China.svg" height="11px"/>
@@ -47,25 +49,25 @@ Available in: <img src="https://upload.wikimedia.org/wikipedia/commons/a/ae/Flag
 ***
 
 <p align="center">
- &bull;
+ •
  <a href="#donations">Donations</a>
- &bull;
+ •
  <a href="#system-requirements">System Requirements</a>
- &bull;
+ •
  <a href="#installation">Installation</a>
- &bull;
+ •
  <a href="#key-features">Key features</a>
- &bull;
+ •
  <a href="#videos">Videos</a>
- &bull;
+ •
  <a href="#screenshots-helen">Screenshots</a>
- &bull;
+ •
  <a href="#addendum">Addendum</a>
- &bull;
+ •
  <a href="#translating">Translating</a>
- &bull;
+ •
  <a href="#media">Media</a>
- &bull;
+ •
  <a href="https://github.com/Sophia-Community/SophiApp/blob/master/CHANGELOG.md">Changelog</a>
 </p>
 
@@ -75,7 +77,7 @@ Available in: <img src="https://upload.wikimedia.org/wikipedia/commons/a/ae/Flag
 
 ![Typing SVG](https://readme-typing-svg.herokuapp.com?font=Fira+Code&size30&pause=1000&width=435&lines=Made+with+%E2%9D%A4%EF%B8%8F+of+Windows%C2%AE)
 
-> **Note**: `SophiApp` is a free, open-source app for fine-tuning `Windows 10` & `Windows 11`. It offers a modern UI/UX, more than 130 unique tweaks, and shows how Windows can be configured without making any harm to the OS.
+> `SophiApp` is a free, open-source app for fine-tuning `Windows 10` & `Windows 11`. It offers a modern UI/UX, more than 130 unique tweaks, and shows how Windows can be configured without making any harm to the OS.
 
 ## Donations
 
@@ -85,19 +87,21 @@ Available in: <img src="https://upload.wikimedia.org/wikipedia/commons/a/ae/Flag
 
 ![ko-fi](https://storage.ko-fi.com/cdn/useruploads/Q5Q51QUJC/qrcode.png)
 
-|                 BTC                 |            USDT (TRC20)              |                    ETH                     |
-|:-----------------------------------:|:------------------------------------:|:------------------------------------------:|
-|<img src="./img/BTC.png" width=130px>|<img src="./img/USDT.png" width=130px>|<img src="./img/ETH.png" width=130px>       |
-|`13QVRYxgGjZtKQgfb6VPRZyyUmnqeaTm1n` |`TQtMjdocUWbKAeg1kLtB4ApjAVHt1v8Rtf`  |`0x089f05c00e2f75e9b0cd939f21c207b1afe5b2f6`|
+| BTC                                   | USDT (TRC20)                           | ETH                                          |
+|:-------------------------------------:|:--------------------------------------:|:--------------------------------------------:|
+| <img src="./img/BTC.png" width=130px> | <img src="./img/USDT.png" width=130px> | <img src="./img/ETH.png" width=130px>        |
+| `13QVRYxgGjZtKQgfb6VPRZyyUmnqeaTm1n`  | `TQtMjdocUWbKAeg1kLtB4ApjAVHt1v8Rtf`   | `0x089f05c00e2f75e9b0cd939f21c207b1afe5b2f6` |
 
 ### System Requirements
 
-|            Version              |    Marketing name       |    Build    |    Arch     |        Editions          |
-|:--------------------------------|------------------------:|:-----------:|:-----------:|:------------------------:|
-| Windows 11 Insider Preview 23H2 |      2023 Update        |   25206+    |             | Home/Pro/Enterprise      |
-| Windows 11 22H2                 |      2022 Update        |   22621+    |             | Home/Pro/Enterprise      |
-| Windows 11 21H2                 |                         | 22000.739+  |             | Home/Pro/Enterprise      |
-| Windows 10 21H2                 |   October 2021 Update   | 19044.1706+ |     x64     | Home/Pro/Enterprise/LTSC |
+| Version                         | Marketing name      | Build       | Arch | Editions                 |
+|:------------------------------- | -------------------:|:-----------:|:----:|:------------------------:|
+| Windows 11 Insider Preview 23H2 | 2023 Update         | 25206+      |      | Home/Pro/Enterprise      |
+| Windows 11 22H2                 | 2022 Update         | 22621+      |      | Home/Pro/Enterprise      |
+| Windows 11 21H2                 |                     | 22000.739+  |      | Home/Pro/Enterprise      |
+| Windows 10 21H2                 | October 2021 Update | 19044.1706+ | x64  | Home/Pro/Enterprise/LTSC |
+
+Check out the [Windows 10](https://support.microsoft.com/en-us/topic/windows-10-update-history-7dd3071a-3906-fa2c-c342-f7f86728a6e3), [Windows 11](https://support.microsoft.com/topic/windows-11-update-history-a19cd327-b57f-44b9-84e0-26ced7109ba9), and [Windows 11 Insider Preview](https://docs.microsoft.com/en-us/windows-insider/flight-hub/) release history 
 
 ### Download SophiApp via PowerShell/Chocolatey/Scoop
 
@@ -120,20 +124,18 @@ scoop bucket add extras
 scoop install sophiapp
 ```
 
-### Beta versions
+ [Beta versions](https://github.com/Sophia-Community/SophiApp/releases)
 
-[Download](https://github.com/Sophia-Community/SophiApp/releases)
+
+
+> `SophiApp` is fully portable: it doesn't have any config (yet) and doesn't save any data into the registry. Just extract the `SophiApp` folder with `Bin` folder and `SophiApp.exe.config` file, and run `SophiApp.exe`
 
 ***
 
-Check out the [Windows 10](https://support.microsoft.com/en-us/topic/windows-10-update-history-7dd3071a-3906-fa2c-c342-f7f86728a6e3), [Windows 11](https://support.microsoft.com/topic/windows-11-update-history-a19cd327-b57f-44b9-84e0-26ced7109ba9), and [Windows 11 Insider Preview](https://docs.microsoft.com/en-us/windows-insider/flight-hub/) release history:
+### Warning:
 
-* It's allowed to be logged in one admin user only during application startup.
-* 🔥🔥🔥`SophiApp` may not work on a homebrew Windows. Especially, if homebrew image was created by OS makers being all thumbs who break Microsoft Defender and disable OS telemetry by uprooting system components on purpose.
-
-## Installation
-
-`SophiApp` is fully portable: it doesn't have any config (yet) and doesn't save any data into registry. Just extract the `SophiApp` folder with `Bin` folder and `SophiApp.exe.config` file, and run `SophiApp.exe`
+* It's allowed to be logged in as one admin user only during application startup.
+* 🔥🔥🔥`SophiApp` may not work on a homebrew Windows. Especially, if the homebrew image was created by OS makers being all thumbs who break Microsoft Defender and disable OS telemetry by purposely uprooting system components
 
 ## Key features
 
@@ -141,13 +143,13 @@ Check out the [Windows 10](https://support.microsoft.com/en-us/topic/windows-10-
 * 130+ tweaks. ⭐
 * `SophiApp` uses the [MVVM](https://en.wikipedia.org/wiki/Model-view-viewmodel) pattern.
 * Multithreading support.
-* `SophiApp` is checked by the [static analyzer](https://pvs-studio.com/pvs-studio), the license for which by courtesy of PVS-Studio.
+* Checked by the [static analyzer](https://pvs-studio.com/pvs-studio), the license for which by courtesy of PVS-Studio.
   * Big thanks to them for providing us the [license](https://pvs-studio.com/en/order/open-source-license).
 * All builds are compiled in cloud via [GitHub Actions](https://github.com/Sophia-Community/SophiApp/actions)
-  * You may compare a zip archive hash sum on the release page with the hash in cloud console in the `Compress Files` category to be sure that the archive wasn't spoofed (you have to be logged into you GitHub account to be able to view Actions logs);
+  * You may compare a zip archive hash sum on the release page with the hash in cloud console in the `Compress Files` category to be sure that the archive wasn't spoofed (you have to be logged into your GitHub account to be able to view Actions logs);
 * The app shows the `actual` state of every feature in the UI.
 * High resolutions support.
-* It has a built-in search engine.
+* Built-in search engine.
   * Functions can be found by searching their headers and descriptions. [GIF](#searching-feature)
 * Dark & light themes support.
   * The app can change its' theme instantly when you change your default Windows theme mode for apps. [GIF](#instantly-changing-theme)
@@ -166,7 +168,7 @@ Check out the [Windows 10](https://support.microsoft.com/en-us/topic/windows-10-
   * `%SystemRoot%\SoftwareDistribution\Download`
   * `%TEMP%`
 * Configure the Windows security.
-* The ability to copy functions' description or header.
+* The ability to copy functions' descriptions or headers.
 * Many more File Explorer and context menu "deep" tweaks.
 
 ## Videos
@@ -199,8 +201,8 @@ Check out the [Windows 10](https://support.microsoft.com/en-us/topic/windows-10-
 
 * Some functions depend on Internet access. If not, they will be hidden in UI until the access appears back.
 * You can enable hidden functions in UI by turning on the `Advanced settings` in the Settings.
-  * The hidden functions will marked with a gear in UI.
-* After closing `SophiApp`, it creates a log file that you can attach to an open issue (or send to the [Telegram](https://t.me/sophia_chat) group) to help us understand bug. The log file doesn't contain any sensitive personal information. We do not store any data neither in the Windows registry or any other server.
+  * The hidden functions will be marked with a gear in UI.
+* After closing `SophiApp`, it creates a log file that you can attach to an open issue (or send to the [Telegram](https://t.me/sophia_chat) group) to help us understand the bug. The log file doesn't contain any sensitive personal information. We do not store any data neither in the Windows registry or any other server.
 
 ## Translating
 


### PR DESCRIPTION
Changes

- Typo and so on
- moved the windows release history near supported versions(where it's really needed)
- Removed from the app description "Note:"
- changed beta version structure
- Merged download with installation
- Create a warning section with homebrew/one admin account 
- Removed some "SophiApp as"/"it has"