### PR TITLE
Move to dotnet CDN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ All efforts are directed towards the SophiApp 2.0 development. Read more: <https
   * https://raw.githubusercontent.com
   * https://github.com
   * https://download.visualstudio.microsoft.com
-  * https://dotnetcli.blob.core.windows.net
+  * https://builds.dotnet.microsoft.com.blob.core.windows.net
   * https://www.google.com
   * https://g.live.com
   * https://oneclient.sfx.ms

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ All efforts are directed towards the SophiApp 2.0 development. Read more: <https
   * https://raw.githubusercontent.com
   * https://github.com
   * https://download.visualstudio.microsoft.com
-  * https://builds.dotnet.microsoft.com.blob.core.windows.net
+  * https://builds.dotnet.microsoft.com
   * https://www.google.com
   * https://g.live.com
   * https://oneclient.sfx.ms

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ scoop install sophiapp
   * <https://raw.githubusercontent.com>
   * <https://github.com>
   * <https://download.visualstudio.microsoft.com>
-  * <https://dotnetcli.blob.core.windows.net>
+  * <https://builds.dotnet.microsoft.com.blob.core.windows.net>
   * <https://www.google.com>
   * <https://g.live.com>
   * <https://oneclient.sfx.ms>

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ scoop install sophiapp
   * <https://raw.githubusercontent.com>
   * <https://github.com>
   * <https://download.visualstudio.microsoft.com>
-  * <https://builds.dotnet.microsoft.com.blob.core.windows.net>
+  * <https://builds.dotnet.microsoft.com>
   * <https://www.google.com>
   * <https://g.live.com>
   * <https://oneclient.sfx.ms>

--- a/README_cn-si.md
+++ b/README_cn-si.md
@@ -235,7 +235,7 @@ scoop install sophiapp
   * <https://raw.githubusercontent.com>
   * <https://github.com>
   * <https://download.visualstudio.microsoft.com>
-  * <https://dotnetcli.blob.core.windows.net>
+  * <https://builds.dotnet.microsoft.com.blob.core.windows.net>
   * <https://www.google.com>
   * <https://g.live.com>
   * <https://oneclient.sfx.ms>

--- a/README_cn-si.md
+++ b/README_cn-si.md
@@ -235,7 +235,7 @@ scoop install sophiapp
   * <https://raw.githubusercontent.com>
   * <https://github.com>
   * <https://download.visualstudio.microsoft.com>
-  * <https://builds.dotnet.microsoft.com.blob.core.windows.net>
+  * <https://builds.dotnet.microsoft.com>
   * <https://www.google.com>
   * <https://g.live.com>
   * <https://oneclient.sfx.ms>

--- a/README_de-de.md
+++ b/README_de-de.md
@@ -238,7 +238,7 @@ scoop install sophiapp
   * <https://raw.githubusercontent.com>
   * <https://github.com>
   * <https://download.visualstudio.microsoft.com>
-  * <https://dotnetcli.blob.core.windows.net>
+  * <https://builds.dotnet.microsoft.com.blob.core.windows.net>
   * <https://www.google.com>
   * <https://g.live.com>
   * <https://oneclient.sfx.ms>

--- a/README_de-de.md
+++ b/README_de-de.md
@@ -238,7 +238,7 @@ scoop install sophiapp
   * <https://raw.githubusercontent.com>
   * <https://github.com>
   * <https://download.visualstudio.microsoft.com>
-  * <https://builds.dotnet.microsoft.com.blob.core.windows.net>
+  * <https://builds.dotnet.microsoft.com>
   * <https://www.google.com>
   * <https://g.live.com>
   * <https://oneclient.sfx.ms>

--- a/README_it-it.md
+++ b/README_it-it.md
@@ -237,7 +237,7 @@ scoop install sophiapp
   * <https://raw.githubusercontent.com>
   * <https://github.com>
   * <https://download.visualstudio.microsoft.com>
-  * <https://builds.dotnet.microsoft.com.blob.core.windows.net>
+  * <https://builds.dotnet.microsoft.com>
   * <https://www.google.com>
   * <https://g.live.com>
   * <https://oneclient.sfx.ms>

--- a/README_it-it.md
+++ b/README_it-it.md
@@ -237,7 +237,7 @@ scoop install sophiapp
   * <https://raw.githubusercontent.com>
   * <https://github.com>
   * <https://download.visualstudio.microsoft.com>
-  * <https://dotnetcli.blob.core.windows.net>
+  * <https://builds.dotnet.microsoft.com.blob.core.windows.net>
   * <https://www.google.com>
   * <https://g.live.com>
   * <https://oneclient.sfx.ms>

--- a/README_ru-ru.md
+++ b/README_ru-ru.md
@@ -237,7 +237,7 @@ scoop install sophiapp
   * <https://raw.githubusercontent.com>
   * <https://github.com>
   * <https://download.visualstudio.microsoft.com>
-  * <https://builds.dotnet.microsoft.com.blob.core.windows.net>
+  * <https://builds.dotnet.microsoft.com>
   * <https://www.google.com>
   * <https://g.live.com>
   * <https://oneclient.sfx.ms>

--- a/README_ru-ru.md
+++ b/README_ru-ru.md
@@ -237,7 +237,7 @@ scoop install sophiapp
   * <https://raw.githubusercontent.com>
   * <https://github.com>
   * <https://download.visualstudio.microsoft.com>
-  * <https://dotnetcli.blob.core.windows.net>
+  * <https://builds.dotnet.microsoft.com.blob.core.windows.net>
   * <https://www.google.com>
   * <https://g.live.com>
   * <https://oneclient.sfx.ms>

--- a/README_tr-tr.md
+++ b/README_tr-tr.md
@@ -236,7 +236,7 @@ scoop install sophiapp
   * <https://raw.githubusercontent.com>
   * <https://github.com>
   * <https://download.visualstudio.microsoft.com>
-  * <https://dotnetcli.blob.core.windows.net>
+  * <https://builds.dotnet.microsoft.com.blob.core.windows.net>
   * <https://www.google.com>
   * <https://g.live.com>
   * <https://oneclient.sfx.ms>

--- a/README_tr-tr.md
+++ b/README_tr-tr.md
@@ -236,7 +236,7 @@ scoop install sophiapp
   * <https://raw.githubusercontent.com>
   * <https://github.com>
   * <https://download.visualstudio.microsoft.com>
-  * <https://builds.dotnet.microsoft.com.blob.core.windows.net>
+  * <https://builds.dotnet.microsoft.com>
   * <https://www.google.com>
   * <https://g.live.com>
   * <https://oneclient.sfx.ms>

--- a/README_uk-ua.md
+++ b/README_uk-ua.md
@@ -239,7 +239,7 @@ scoop install sophiapp
   * <https://raw.githubusercontent.com>
   * <https://github.com>
   * <https://download.visualstudio.microsoft.com>
-  * <https://dotnetcli.blob.core.windows.net>
+  * <https://builds.dotnet.microsoft.com.blob.core.windows.net>
   * <https://www.google.com>
   * <https://g.live.com>
   * <https://oneclient.sfx.ms>

--- a/README_uk-ua.md
+++ b/README_uk-ua.md
@@ -239,7 +239,7 @@ scoop install sophiapp
   * <https://raw.githubusercontent.com>
   * <https://github.com>
   * <https://download.visualstudio.microsoft.com>
-  * <https://builds.dotnet.microsoft.com.blob.core.windows.net>
+  * <https://builds.dotnet.microsoft.com>
   * <https://www.google.com>
   * <https://g.live.com>
   * <https://oneclient.sfx.ms>

--- a/src/SophiApp/Customisations/CustomisationOs.cs
+++ b/src/SophiApp/Customisations/CustomisationOs.cs
@@ -960,7 +960,7 @@ namespace SophiApp.Customisations
         public static void _354(bool _)
         {
             var temp = Environment.GetEnvironmentVariable(TEMP);
-            var cloudNet6 = WebHelper.GetJsonResponse<MsNetDto>(@"https://builds.dotnet.microsoft.com.blob.core.windows.net/dotnet/release-metadata/6.0/releases.json");
+            var cloudNet6 = WebHelper.GetJsonResponse<MsNetDto>(@"https://builds.dotnet.microsoft.com/dotnet/release-metadata/6.0/releases.json");
             var latestRelease = cloudNet6.Releases.Where(release => release.ReleaseVersion == $"{cloudNet6.LatestRelease}").First();
             var latestRuntime = latestRelease.WindowsDesktop.Files.Where(file => file.Name == "windowsdesktop-runtime-win-x86.exe").First();
             var installer = $@"{temp}\{latestRuntime.Url.Substring(latestRuntime.Url.LastIndexOf('/') + 1)}";

--- a/src/SophiApp/Customisations/CustomisationOs.cs
+++ b/src/SophiApp/Customisations/CustomisationOs.cs
@@ -984,7 +984,7 @@ namespace SophiApp.Customisations
         public static void _357(bool _)
         {
             var temp = Environment.GetEnvironmentVariable(TEMP);
-            var cloudNet6 = WebHelper.GetJsonResponse<MsNetDto>(@"https://builds.dotnet.microsoft.com.blob.core.windows.net/dotnet/release-metadata/6.0/releases.json");
+            var cloudNet6 = WebHelper.GetJsonResponse<MsNetDto>(@"https://builds.dotnet.microsoft.com/dotnet/release-metadata/6.0/releases.json");
             var latestRelease = cloudNet6.Releases.Where(release => release.ReleaseVersion == $"{cloudNet6.LatestRelease}").First();
             var latestRuntime = latestRelease.WindowsDesktop.Files.Where(file => file.Name == "windowsdesktop-runtime-win-x64.exe").First();
             var installer = $@"{temp}\{latestRuntime.Url.Substring(latestRuntime.Url.LastIndexOf('/') + 1)}";

--- a/src/SophiApp/Customisations/CustomisationOs.cs
+++ b/src/SophiApp/Customisations/CustomisationOs.cs
@@ -960,7 +960,7 @@ namespace SophiApp.Customisations
         public static void _354(bool _)
         {
             var temp = Environment.GetEnvironmentVariable(TEMP);
-            var cloudNet6 = WebHelper.GetJsonResponse<MsNetDto>(@"https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/6.0/releases.json");
+            var cloudNet6 = WebHelper.GetJsonResponse<MsNetDto>(@"https://builds.dotnet.microsoft.com.blob.core.windows.net/dotnet/release-metadata/6.0/releases.json");
             var latestRelease = cloudNet6.Releases.Where(release => release.ReleaseVersion == $"{cloudNet6.LatestRelease}").First();
             var latestRuntime = latestRelease.WindowsDesktop.Files.Where(file => file.Name == "windowsdesktop-runtime-win-x86.exe").First();
             var installer = $@"{temp}\{latestRuntime.Url.Substring(latestRuntime.Url.LastIndexOf('/') + 1)}";
@@ -984,7 +984,7 @@ namespace SophiApp.Customisations
         public static void _357(bool _)
         {
             var temp = Environment.GetEnvironmentVariable(TEMP);
-            var cloudNet6 = WebHelper.GetJsonResponse<MsNetDto>(@"https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/6.0/releases.json");
+            var cloudNet6 = WebHelper.GetJsonResponse<MsNetDto>(@"https://builds.dotnet.microsoft.com.blob.core.windows.net/dotnet/release-metadata/6.0/releases.json");
             var latestRelease = cloudNet6.Releases.Where(release => release.ReleaseVersion == $"{cloudNet6.LatestRelease}").First();
             var latestRuntime = latestRelease.WindowsDesktop.Files.Where(file => file.Name == "windowsdesktop-runtime-win-x64.exe").First();
             var installer = $@"{temp}\{latestRuntime.Url.Substring(latestRuntime.Url.LastIndexOf('/') + 1)}";

--- a/src/SophiApp/Customisations/CustomisationStatus.cs
+++ b/src/SophiApp/Customisations/CustomisationStatus.cs
@@ -455,7 +455,7 @@ namespace SophiApp.Customisations
         {
             if (HttpHelper.IsOnline)
             {
-                var cloudNetVersion = WebHelper.GetJsonResponse<MsNetDto>(@"https://builds.dotnet.microsoft.com.blob.core.windows.net/dotnet/release-metadata/6.0/releases.json");
+                var cloudNetVersion = WebHelper.GetJsonResponse<MsNetDto>(@"https://builds.dotnet.microsoft.com/dotnet/release-metadata/6.0/releases.json");
                 return DotNetHelper.IsInstalled(cloudNetVersion.LatestRelease, DotNetRid.Win_x86)
                         ? throw new DotNetInstalledException(cloudNetVersion.LatestRelease)
                         : false;
@@ -472,7 +472,7 @@ namespace SophiApp.Customisations
         {
             if (HttpHelper.IsOnline)
             {
-                var cloudNetVersion = WebHelper.GetJsonResponse<MsNetDto>(@"https://builds.dotnet.microsoft.com.blob.core.windows.net/dotnet/release-metadata/6.0/releases.json");
+                var cloudNetVersion = WebHelper.GetJsonResponse<MsNetDto>(@"https://builds.dotnet.microsoft.com/dotnet/release-metadata/6.0/releases.json");
                 return DotNetHelper.IsInstalled(cloudNetVersion.LatestRelease, DotNetRid.Win_x64)
                         ? throw new DotNetInstalledException(cloudNetVersion.LatestRelease)
                         : false;

--- a/src/SophiApp/Customisations/CustomisationStatus.cs
+++ b/src/SophiApp/Customisations/CustomisationStatus.cs
@@ -455,7 +455,7 @@ namespace SophiApp.Customisations
         {
             if (HttpHelper.IsOnline)
             {
-                var cloudNetVersion = WebHelper.GetJsonResponse<MsNetDto>(@"https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/6.0/releases.json");
+                var cloudNetVersion = WebHelper.GetJsonResponse<MsNetDto>(@"https://builds.dotnet.microsoft.com.blob.core.windows.net/dotnet/release-metadata/6.0/releases.json");
                 return DotNetHelper.IsInstalled(cloudNetVersion.LatestRelease, DotNetRid.Win_x86)
                         ? throw new DotNetInstalledException(cloudNetVersion.LatestRelease)
                         : false;
@@ -472,7 +472,7 @@ namespace SophiApp.Customisations
         {
             if (HttpHelper.IsOnline)
             {
-                var cloudNetVersion = WebHelper.GetJsonResponse<MsNetDto>(@"https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/6.0/releases.json");
+                var cloudNetVersion = WebHelper.GetJsonResponse<MsNetDto>(@"https://builds.dotnet.microsoft.com.blob.core.windows.net/dotnet/release-metadata/6.0/releases.json");
                 return DotNetHelper.IsInstalled(cloudNetVersion.LatestRelease, DotNetRid.Win_x64)
                         ? throw new DotNetInstalledException(cloudNetVersion.LatestRelease)
                         : false;


### PR DESCRIPTION
We want to move everyone to our new CDN. This is, in part, due to breakage that doesn't affect your usage (since you are using the underlying storage account).

Related: https://github.com/dotnet/core/issues/9671